### PR TITLE
API에서 응답 받은 이미지를 사용한 카드 스와이프 기능 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,33 @@
+import { getData } from "./src/util/fetch.js";
+import { Item } from "./src/components/Item.js";
+function app() {
+    //쓰로틀 적용 예정
+    document.querySelector("#btn_like").onclick = () => {
+        swipe("like");
+    };
+    document.querySelector("#btn_dislike").onclick = () => {
+        swipe("dislike");
+    };
+
+    let $cardContainer = document.querySelector("#card_container");
+    let current;
+    $cardContainer.append(Item(), Item());
+
+    current = $cardContainer.querySelector(".card:last-child");
+    const swipe = (action) => {
+        current.classList.add(action);
+        const prev = current;
+        const next = current.previousElementSibling;
+        // if (nextCard) initEventCard(nextCard);
+        // nextCard가 없으면 다음 데이터를 fetch해서 카드를 생성해야함; 다음이 아니라 다다음 카드가 없을때부태 fetch해서 로딩을 줄일 수 있음
+        current = next;
+        $cardContainer.insertBefore(Item({ id: 10 }), $cardContainer.children[0]);
+
+        const RemoveSwipedCard = () => {
+            $cardContainer.removeChild(prev);
+            prev.removeEventListener("animationend", RemoveSwipedCard);
+        };
+        prev.addEventListener("animationend", RemoveSwipedCard);
+    };
+}
+app();

--- a/index.html
+++ b/index.html
@@ -1,10 +1,20 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Photo swipe</title>
-  </head>
-  <body>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="./src/style/reset.css" />
+        <link rel="stylesheet" href="./src/style/index.scss" />
+        <title>Photo swipe</title>
+    </head>
+    <body>
+        <div id="frame">
+            <div id="card_container"></div>
+            <div id="button_container">
+                <button id="btn_dislike">X</button>
+                <button id="btn_like">O</button>
+            </div>
+        </div>
+        <script defer type="module" src="./app.js"></script>
+    </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
             <div id="frame">
                 <div id="card_container"></div>
                 <div id="button_container">
-                    <button id="btn_dislike">X</button>
-                    <button id="btn_like">O</button>
+                    <button data-btn-preference="dislike">X</button>
+                    <button data-btn-preference="like">O</button>
                 </div>
             </div>
         </main>

--- a/index.html
+++ b/index.html
@@ -8,13 +8,15 @@
         <title>Photo swipe</title>
     </head>
     <body>
-        <div id="frame">
-            <div id="card_container"></div>
-            <div id="button_container">
-                <button id="btn_dislike">X</button>
-                <button id="btn_like">O</button>
+        <main>
+            <div id="frame">
+                <div id="card_container"></div>
+                <div id="button_container">
+                    <button id="btn_dislike">X</button>
+                    <button id="btn_like">O</button>
+                </div>
             </div>
-        </div>
-        <script defer type="module" src="./app.js"></script>
+        </main>
+        <script defer type="module" src="./src/app.js"></script>
     </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -6,19 +6,15 @@ function app() {
     const btnDislike = document.querySelector('[data-btn-preference="dislike"]');
     btnLike.classList.add("active");
     btnDislike.classList.add("active");
-    const toggleStyle = () => {
-        btnLike.classList.toggle("active");
-        btnDislike.classList.toggle("active");
-        btnLike.classList.toggle("deactive");
-        btnDislike.classList.toggle("deactive");
-    };
     const thorttle = (func) => {
         if (!timer) {
             func();
-            toggleStyle();
+            btnLike.classList.replace("active", "deactive");
+            btnDislike.classList.replace("active", "deactive");
             timer = setTimeout(() => {
                 timer = null;
-                toggleStyle();
+                btnLike.classList.replace("deactive", "active");
+                btnDislike.classList.replace("deactive", "active");
             }, 500);
         }
     };

--- a/src/app.js
+++ b/src/app.js
@@ -2,11 +2,25 @@
 import { Item } from "./components/Item.js";
 function app() {
     //쓰로틀 적용 예정
-    document.querySelector("#btn_like").onclick = () => {
-        swipe("like");
+    //쓰로틀로 이벤트 대기중일때는 버튼이 비활성화된 스타일을 보여줘야 UX 향상함
+    let timer = null;
+    const btnLike = document.querySelector("#btn_like");
+    const btnDislike = document.querySelector("#btn_dislike");
+    const thorttle = (func, el) => {
+        if (!timer) {
+            func();
+            el.classList.add("deactive");
+            timer = setTimeout(() => {
+                timer = null;
+                el.classList.remove("deactive");
+            }, 500);
+        }
     };
-    document.querySelector("#btn_dislike").onclick = () => {
-        swipe("dislike");
+    btnLike.onclick = () => {
+        thorttle(() => swipe("like"), btnLike);
+    };
+    btnDislike.onclick = () => {
+        thorttle(() => swipe("dislike"), btnDislike);
     };
 
     let $cardContainer = document.querySelector("#card_container");
@@ -14,8 +28,8 @@ function app() {
     $cardContainer.append(Item(), Item());
 
     current = $cardContainer.querySelector(".card:last-child");
-    const swipe = (action) => {
-        current.classList.add(action);
+    const swipe = (preference) => {
+        current.classList.add(preference);
         const prev = current;
         const next = current.previousElementSibling;
         // if (nextCard) initEventCard(nextCard);

--- a/src/app.js
+++ b/src/app.js
@@ -37,7 +37,6 @@ function app() {
             }
         };
     };
-
     const InitData = async () => {
         targetArr = await getCardDataFromId(cardIdArr); //[0,1,2,3,4]
         for (let i = targetArr.length - 1; i >= 0; i--) {
@@ -48,28 +47,26 @@ function app() {
         bufferArr = await getCardDataFromId(cardIdArr);
     };
     const InsertCard = async () => {
-        let curCardId = parseInt($currentCard.id);
-        if (curCardId === targetArr.at(-1).id) {
-            console.log(curCardId, targetArr.at(-1).id);
-            console.log("last target card");
-            targetArr = bufferArr;
-            cardIdArr = cardIdArr.map((el) => el + RENDER_CARD_NUM);
-            bufferArr = await getCardDataFromId(cardIdArr);
-            console.log(targetArr, "|", bufferArr);
-            console.log(curCardId, targetArr.at(-1).id);
-            console.log(targetArr, bufferArr);
-            $cardContainer.insertBefore(
-                Item(targetArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0]),
-                $cardContainer.firstElementChild
-            );
-        } else {
-            $cardContainer.insertBefore(
-                Item(bufferArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0]),
-                $cardContainer.firstElementChild
-            );
+        try {
+            let curCardId = parseInt($currentCard.id);
+            if (curCardId === targetArr.at(-1).id) {
+                targetArr = bufferArr;
+                cardIdArr = cardIdArr.map((el) => el + RENDER_CARD_NUM);
+                bufferArr = await getCardDataFromId(cardIdArr);
+                $cardContainer.insertBefore(
+                    Item(targetArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0]),
+                    $cardContainer.firstElementChild
+                );
+            } else {
+                $cardContainer.insertBefore(
+                    Item(bufferArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0]),
+                    $cardContainer.firstElementChild
+                );
+            }
+        } catch (e) {
+            console.log("카드 추가 중 오류 발생", e);
         }
     };
-
     const RemoveCard = (preference) => {
         try {
             $currentCard.classList.add(`action_${preference}`);
@@ -81,15 +78,13 @@ function app() {
             };
             $prevCard.addEventListener("animationend", RemoveSwipedCard);
         } catch (e) {
-            console.log(e);
+            console.log("카드 추가 중 오류 발생", e);
         }
     };
-
     const Swipe = (preference) => {
         InsertCard();
         RemoveCard(preference);
     };
-
     InitBtn();
     InitData();
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
-import { getData } from "./src/util/fetch.js";
-import { Item } from "./src/components/Item.js";
+// import { getData } from "./util/fetch.js";
+import { Item } from "./components/Item.js";
 function app() {
     //쓰로틀 적용 예정
     document.querySelector("#btn_like").onclick = () => {

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 import { getCardDataFromId } from "./util/fetch.js";
 import { Item } from "./components/Item.js";
 
-const RENDER_CARD_NUM = 3;
+const RENDER_CARD_NUM = 5;
 
 function app() {
     let $cardContainer = document.querySelector("#card_container");
@@ -49,19 +49,12 @@ function app() {
     const InsertCard = async () => {
         try {
             let curCardId = parseInt($currentCard.id);
+            const renderItem = bufferArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0];
+            $cardContainer.insertBefore(Item(renderItem), $cardContainer.firstElementChild);
             if (curCardId === targetArr.at(-1).id) {
                 targetArr = bufferArr;
                 cardIdArr = cardIdArr.map((el) => el + RENDER_CARD_NUM);
                 bufferArr = await getCardDataFromId(cardIdArr);
-                $cardContainer.insertBefore(
-                    Item(targetArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0]),
-                    $cardContainer.firstElementChild
-                );
-            } else {
-                $cardContainer.insertBefore(
-                    Item(bufferArr.filter((el) => el.id === curCardId + RENDER_CARD_NUM)[0]),
-                    $cardContainer.firstElementChild
-                );
             }
         } catch (e) {
             console.log("카드 추가 중 오류 발생", e);

--- a/src/app.js
+++ b/src/app.js
@@ -1,47 +1,88 @@
-// import { getData } from "./util/fetch.js";
+import { getCardData } from "./util/fetch.js";
 import { Item } from "./components/Item.js";
 function app() {
+    let $cardContainer = document.querySelector("#card_container");
+    let $currentCard;
     let timer = null;
-    const btnLike = document.querySelector('[data-btn-preference="like"]');
-    const btnDislike = document.querySelector('[data-btn-preference="dislike"]');
-    btnLike.classList.add("active");
-    btnDislike.classList.add("active");
-    const thorttle = (func) => {
-        if (!timer) {
-            func();
-            btnLike.classList.replace("active", "deactive");
-            btnDislike.classList.replace("active", "deactive");
-            timer = setTimeout(() => {
-                timer = null;
-                btnLike.classList.replace("deactive", "active");
-                btnDislike.classList.replace("deactive", "active");
-            }, 500);
+    let cardIdArr = [0, 1, 2, 3, 4];
+    let currentCardDataArr = [],
+        nextCardDataArr = [];
+    let cardIdIndex = 0;
+
+    const InitBtn = () => {
+        const $btnLike = document.querySelector('[data-btn-preference="like"]');
+        const $btnDislike = document.querySelector('[data-btn-preference="dislike"]');
+        $btnLike.classList.add("active");
+        $btnDislike.classList.add("active");
+
+        const btnThorttle = (func) => {
+            if (!timer) {
+                func();
+                $btnLike.classList.replace("active", "deactive");
+                $btnDislike.classList.replace("active", "deactive");
+                timer = setTimeout(() => {
+                    timer = null;
+                    $btnLike.classList.replace("deactive", "active");
+                    $btnDislike.classList.replace("deactive", "active");
+                }, 500);
+            }
+        };
+
+        $btnLike.onclick = (e) => {
+            btnThorttle(() => Swipe(e.target.dataset.btnPreference));
+        };
+        $btnDislike.onclick = (e) => {
+            btnThorttle(() => Swipe(e.target.dataset.btnPreference));
+        };
+    };
+
+    const InitData = async () => {
+        currentCardDataArr = await getCardData(cardIdArr); //[0,1,2,3,4]
+        for (let i = cardIdArr.length - 1; i >= 0; i--) {
+            console.log(currentCardDataArr[i]);
+            $cardContainer.appendChild(Item(currentCardDataArr[i]));
+            cardIdIndex++;
+        }
+        cardIdArr = cardIdArr.map((el) => el + 5);
+        nextCardDataArr = await getCardData(cardIdArr); //[5,6,7,8,9]
+        $currentCard = $cardContainer.querySelector(".card:last-child");
+    };
+
+    const InsertCard = () => {
+        if (cardIdIndex >= 5) {
+            currentCardDataArr = nextCardDataArr;
+            //currentCardDataArr = [5,6,7,8,9]
+            cardIdArr = cardIdArr.map((el) => el + 5);
+            (async () => {
+                nextCardDataArr = await getCardData(cardIdArr);
+            })();
+            //nextCardDataArr = [10,11,12,13,14]
+            cardIdIndex = 0;
+        }
+        $cardContainer.insertBefore(Item(currentCardDataArr[cardIdIndex]), $cardContainer.firstElementChild);
+        cardIdIndex++;
+    };
+
+    const Swipe = (preference) => {
+        try {
+            $currentCard.classList.add(`action_${preference}`);
+            const $prev = $currentCard;
+            const $next = $currentCard.previousElementSibling;
+            $currentCard = $next;
+
+            const RemoveSwipedCard = () => {
+                $cardContainer.removeChild($prev);
+                $prev.removeEventListener("animationend", RemoveSwipedCard);
+            };
+            $prev.addEventListener("animationend", RemoveSwipedCard);
+
+            InsertCard();
+        } catch (e) {
+            console.log(e);
         }
     };
-    btnLike.onclick = (e) => {
-        thorttle(() => swipe(e.target.dataset.btnPreference));
-    };
-    btnDislike.onclick = (e) => {
-        thorttle(() => swipe(e.target.dataset.btnPreference));
-    };
 
-    let $cardContainer = document.querySelector("#card_container");
-    let current;
-    $cardContainer.append(Item(), Item());
-
-    current = $cardContainer.querySelector(".card:last-child");
-    const swipe = (preference) => {
-        current.classList.add(`action_${preference}`);
-        const prev = current;
-        const next = current.previousElementSibling;
-        current = next;
-        $cardContainer.insertBefore(Item({ id: 10 }), $cardContainer.children[0]);
-
-        const RemoveSwipedCard = () => {
-            $cardContainer.removeChild(prev);
-            prev.removeEventListener("animationend", RemoveSwipedCard);
-        };
-        prev.addEventListener("animationend", RemoveSwipedCard);
-    };
+    InitBtn();
+    InitData();
 }
 app();

--- a/src/app.js
+++ b/src/app.js
@@ -4,23 +4,25 @@ function app() {
     //쓰로틀 적용 예정
     //쓰로틀로 이벤트 대기중일때는 버튼이 비활성화된 스타일을 보여줘야 UX 향상함
     let timer = null;
-    const btnLike = document.querySelector("#btn_like");
-    const btnDislike = document.querySelector("#btn_dislike");
-    const thorttle = (func, el) => {
+    const btnLike = document.querySelector('[data-btn-preference="like"]');
+    const btnDislike = document.querySelector('[data-btn-preference="dislike"]');
+    const thorttle = (func) => {
         if (!timer) {
             func();
-            el.classList.add("deactive");
+            btnLike.classList.add("deactive");
+            btnDislike.classList.add("deactive");
             timer = setTimeout(() => {
                 timer = null;
-                el.classList.remove("deactive");
+                btnLike.classList.remove("deactive");
+                btnDislike.classList.remove("deactive");
             }, 500);
         }
     };
-    btnLike.onclick = () => {
-        thorttle(() => swipe("like"), btnLike);
+    btnLike.onclick = (e) => {
+        thorttle(() => swipe(e.target.dataset.btnPreference));
     };
-    btnDislike.onclick = () => {
-        thorttle(() => swipe("dislike"), btnDislike);
+    btnDislike.onclick = (e) => {
+        thorttle(() => swipe(e.target.dataset.btnPreference));
     };
 
     let $cardContainer = document.querySelector("#card_container");
@@ -29,7 +31,7 @@ function app() {
 
     current = $cardContainer.querySelector(".card:last-child");
     const swipe = (preference) => {
-        current.classList.add(preference);
+        current.classList.add(`action_${preference}`);
         const prev = current;
         const next = current.previousElementSibling;
         // if (nextCard) initEventCard(nextCard);

--- a/src/app.js
+++ b/src/app.js
@@ -1,20 +1,24 @@
 // import { getData } from "./util/fetch.js";
 import { Item } from "./components/Item.js";
 function app() {
-    //쓰로틀 적용 예정
-    //쓰로틀로 이벤트 대기중일때는 버튼이 비활성화된 스타일을 보여줘야 UX 향상함
     let timer = null;
     const btnLike = document.querySelector('[data-btn-preference="like"]');
     const btnDislike = document.querySelector('[data-btn-preference="dislike"]');
+    btnLike.classList.add("active");
+    btnDislike.classList.add("active");
+    const toggleStyle = () => {
+        btnLike.classList.toggle("active");
+        btnDislike.classList.toggle("active");
+        btnLike.classList.toggle("deactive");
+        btnDislike.classList.toggle("deactive");
+    };
     const thorttle = (func) => {
         if (!timer) {
             func();
-            btnLike.classList.add("deactive");
-            btnDislike.classList.add("deactive");
+            toggleStyle();
             timer = setTimeout(() => {
                 timer = null;
-                btnLike.classList.remove("deactive");
-                btnDislike.classList.remove("deactive");
+                toggleStyle();
             }, 500);
         }
     };
@@ -34,8 +38,6 @@ function app() {
         current.classList.add(`action_${preference}`);
         const prev = current;
         const next = current.previousElementSibling;
-        // if (nextCard) initEventCard(nextCard);
-        // nextCard가 없으면 다음 데이터를 fetch해서 카드를 생성해야함; 다음이 아니라 다다음 카드가 없을때부태 fetch해서 로딩을 줄일 수 있음
         current = next;
         $cardContainer.insertBefore(Item({ id: 10 }), $cardContainer.children[0]);
 

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import { Item } from "./components/Item.js";
 function app() {
     let $cardContainer = document.querySelector("#card_container");
     let $currentCard;
-    let timer = null;
+    let throttleTimer = null;
     let cardIdArr = [0, 1, 2, 3, 4];
     let currentCardDataArr = [],
         nextCardDataArr = [];
@@ -16,12 +16,12 @@ function app() {
         $btnDislike.classList.add("active");
 
         const btnThorttle = (func) => {
-            if (!timer) {
+            if (!throttleTimer) {
                 func();
                 $btnLike.classList.replace("active", "deactive");
                 $btnDislike.classList.replace("active", "deactive");
-                timer = setTimeout(() => {
-                    timer = null;
+                throttleTimer = setTimeout(() => {
+                    throttleTimer = null;
                     $btnLike.classList.replace("deactive", "active");
                     $btnDislike.classList.replace("deactive", "active");
                 }, 500);

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,0 +1,10 @@
+export function Item(_data) {
+    const $figure = document.createElement("figure");
+    $figure.classList.add("card");
+    // $figure.style.backgroundImage = `url(${_data.url})`;
+    const $figcap = document.createElement("figcaption");
+    // $figcap.textContent = _data.id;
+    $figure.appendChild($figcap);
+
+    return $figure;
+}

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,9 +1,9 @@
 export function Item(_data) {
     const $figure = document.createElement("figure");
     $figure.classList.add("card");
-    // $figure.style.backgroundImage = `url(${_data.url})`;
+    $figure.style.backgroundImage = `url(${_data.url})`;
     const $figcap = document.createElement("figcaption");
-    // $figcap.textContent = _data.id;
+    $figcap.textContent = _data.id;
     $figure.appendChild($figcap);
 
     return $figure;

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,5 +1,6 @@
 export function Item(_data) {
     const $figure = document.createElement("figure");
+    $figure.id = _data.id;
     $figure.classList.add("card");
     $figure.style.backgroundImage = `url(${_data.url})`;
     const $figcap = document.createElement("figcaption");

--- a/src/style/button.scss
+++ b/src/style/button.scss
@@ -1,5 +1,16 @@
-.deactive{
-  opacity: 0.5;
-  color: gainsboro;
-  cursor:not-allowed
+.active {
+    opacity: 1;
+    cursor: pointer;
+    &[data-btn-preference="like"] {
+        color: green;
+    }
+    &[data-btn-preference="dislike"] {
+        color: red;
+    }
+}
+
+.deactive {
+    opacity: 0.5;
+    color: white;
+    background-color: gray;
 }

--- a/src/style/button.scss
+++ b/src/style/button.scss
@@ -1,0 +1,5 @@
+.deactive{
+  opacity: 0.5;
+  color: gainsboro;
+  cursor:not-allowed
+}

--- a/src/style/card.scss
+++ b/src/style/card.scss
@@ -1,0 +1,40 @@
+#card_container {
+    position: relative;
+    width: 200px;
+    height: 300px;
+}
+
+.card {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: snow;
+    border: 2px solid black;
+    border-radius: 1rem;
+    transition: transform 1s;
+}
+.like {
+    animation: swipeRight 1s;
+    z-index: 10;
+}
+.dislike {
+    animation: swipeLeft 1s;
+    z-index: 10;
+}
+@keyframes swipeRight {
+    from {
+    }
+    to {
+        transform: translateX(200px);
+    }
+}
+
+@keyframes swipeLeft {
+    from {
+    }
+    to {
+        transform: translateX(-200px);
+    }
+}

--- a/src/style/card.scss
+++ b/src/style/card.scss
@@ -24,16 +24,12 @@
     z-index: 10;
 }
 @keyframes swipeRight {
-    from {
-    }
     to {
         transform: translateX(200px);
     }
 }
 
 @keyframes swipeLeft {
-    from {
-    }
     to {
         transform: translateX(-200px);
     }

--- a/src/style/card.scss
+++ b/src/style/card.scss
@@ -15,11 +15,11 @@
     border-radius: 1rem;
     transition: transform 1s;
 }
-.like {
+.action_like {
     animation: swipeRight 1s;
     z-index: 10;
 }
-.dislike {
+.action_dislike {
     animation: swipeLeft 1s;
     z-index: 10;
 }

--- a/src/style/card.scss
+++ b/src/style/card.scss
@@ -14,6 +14,11 @@
     border: 2px solid black;
     border-radius: 1rem;
     transition: transform 1s;
+    figcaption {
+        text-align: center;
+        font-size: 2rem;
+        background-color: gainsboro;
+    }
 }
 .action_like {
     animation: swipeRight 1s;

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1,7 +1,8 @@
 @import "./reset.css";
 @import "./card.scss";
+@import "./button.scss";
 
-main{
+main {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -18,14 +19,14 @@ main{
 }
 #button_container {
     margin-top: 1rem;
-    button{
+    button {
         background-color: transparent;
         border: none;
         font-size: 2rem;
-        &:first-of-type{
+        &:first-of-type {
             color: red;
         }
-        &:last-of-type{
+        &:last-of-type {
             color: green;
         }
     }

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1,0 +1,32 @@
+@import "./reset.css";
+@import "./card.scss";
+
+main{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100vw;
+    height: 100vh;
+    background-color: cornflowerblue;
+}
+#frame {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+#card_container {
+}
+#button_container {
+    margin-top: 1rem;
+    button{
+        background-color: transparent;
+        border: none;
+        font-size: 2rem;
+        &:first-of-type{
+            color: red;
+        }
+        &:last-of-type{
+            color: green;
+        }
+    }
+}

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -20,14 +20,7 @@ main {
 #button_container {
     margin-top: 1rem;
     button {
-        background-color: transparent;
         border: none;
         font-size: 2rem;
-        &:first-of-type {
-            color: red;
-        }
-        &:last-of-type {
-            color: green;
-        }
     }
 }

--- a/src/style/reset.css
+++ b/src/style/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,0 +1,4 @@
+export async function getData(seed) {
+    const data = await fetch(`https://picsum.photos/100/150?random=${seed}`);
+    return ;
+}

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -5,7 +5,7 @@ const URL = import.meta.env.VITE_URL;
  * @param {Array<number>} cardIdArr
  * @returns {Promise<object>} {id:number,url:string}
  */
-export async function getCardData(cardIdArr) {
+export async function getCardDataFromId(cardIdArr) {
     const result = await Promise.all(
         cardIdArr.map(async (el) => {
             const response = await fetch(URL + `?random=${el}`);

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,6 +1,24 @@
-export async function getData(seed) {
-    const data = await fetch(`https://picsum.photos/100/150?random=${seed}`);
-    return;
+const URL = import.meta.env.VITE_URL;
+
+/**
+ * @async
+ * @param {Array<number>} cardIdArr
+ * @returns {Promise<object>} {id:number,url:string}
+ */
+export async function getCardData(cardIdArr) {
+    const result = await Promise.all(
+        cardIdArr.map(async (el) => {
+            const response = await fetch(URL + `?random=${el}`);
+            let data = null;
+            try {
+                data = await response.json();
+            } catch (error) {
+                data = response;
+            }
+            return { id: el , url: data.url};
+        })
+    );
+    return result;
 }
 
 // fetch 기능

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,4 +1,15 @@
 export async function getData(seed) {
     const data = await fetch(`https://picsum.photos/100/150?random=${seed}`);
-    return ;
+    return;
 }
+
+// fetch 기능
+/**
+ * 1. 렌더링할 5장의 데이터를 fetch하여 let currentCardDataList에 할당한다
+ * 2. currentCardDataList에서 map을 사용해 5장의 카드를 렌더링한다.
+ * 3. 다음에 쓰일 5장의 데이터를 fetch하여 let nextCardDataList에 할당한다
+ * 4. Item을 렌더링할때마다 let counter = 0을 counter++ 한다.
+ * 5. counter가 5가되면 currentCardDataList에 nextCardDataList를 할당한다.
+ * 6. counter = 0으로 초기화한다.
+ * 7. 2부터 반복한다
+ */


### PR DESCRIPTION
### 구현한 내용

1. RENDER_CARD_NUM 전역상수로 렌더링 할 카드의 수를 전역적으로 관리 가능.
2. OX 버튼 이벤트에 스로틀을 적용하여 과도한 API 호출을 방지한다.
3. 현재 렌더링 대상인 카드를 담고 있는 targetArr와 카드를 넘길 때 새로 렌더링되는 카드의 데이터를 담고 있는 bufferArr가 존재한다.
4. targetArr의 마지막 요소까지 렌더링 되면  **targetArr는 bufferArr의 데이터로 교체되고 bufferArr는 새로운 데이터를 fetch한다.**

---

#### 추가적으로 해야 하는 작업

1. 카드 추가와 제거가 데이터 응답보다 먼저 발생할 시 오류 발생
    > 브랜치 bugfix/insert_card 와 bugfix/remove_card에서 작업 예정
    > 카드 추가와 제거 함수의 예외 처리 필요

2. 스타일 디자인 작업
    > 브랜치 feat/add_style_card에서 작업 예정



